### PR TITLE
fix: separate bind address from API address for Docker

### DIFF
--- a/app/src/entry-server.tsx
+++ b/app/src/entry-server.tsx
@@ -16,7 +16,7 @@ export default createHandler(() => (
 				<body class="bg-background-100 text-background-950 dark:text-background-50 dark:bg-background-950">
 					<div id="app">{children}</div>
 					<script
-						innerHTML={`window.__API_ADDRESS__=${JSON.stringify(`${process.env.API_HOST}:${process.env.API_PORT}`)}`}
+						innerHTML={`window.__API_ADDRESS__=${JSON.stringify(`${process.env.BIND_HOST || process.env.API_HOST}:${process.env.BIND_PORT || process.env.API_PORT}`)}`}
 					/>
 					{scripts}
 				</body>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
             API_HOST: ${API_HOST}
             API_PORT: 8080
             API_INTERNAL_HOST: api
+            BIND_HOST: ${BIND_HOST}
+            BIND_PORT: ${BIND_PORT}
         depends_on:
             api:
                 condition: service_started


### PR DESCRIPTION
## Summary

- Fixed port mismatch in Docker environment by introducing separate `BIND_HOST` and `BIND_PORT` environment variables.
- Updated `entry-server.tsx` to fall back to `API_HOST`/`API_PORT` when bind variables are not set.
- Added `BIND_HOST` and `BIND_PORT` to the Docker Compose service definition.

## Testing

- Confirmed the frontend correctly resolves `window.__API_ADDRESS__` using the new bind variables when set.
- Verified fallback to `API_HOST`/`API_PORT` when `BIND_HOST`/`BIND_PORT` are not defined.
- Not run: end-to-end Docker integration test with both `BIND_*` and `API_*` variables configured differently.