### PR TITLE
Separate check workflow from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: Build Containers
 
 on:
-    workflow_dispatch:
+    push:
+        branches: [main]
 
 env:
     REGISTRY: ghcr.io

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,16 +58,6 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
-            - uses: oven-sh/setup-bun@v2
-
-            - name: Install dependencies
-              run: bun install
-              working-directory: app
-
-            - name: Run App checks
-              run: bun run check
-              working-directory: app
-
             - name: Log in to GitHub Container Registry
               uses: docker/login-action@v4
               with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,76 @@
+name: Check
+
+on:
+    pull_request:
+        branches: [main]
+
+jobs:
+    check-api:
+        name: Check API
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v7
+
+            - name: Cache cargo
+              uses: actions/cache@v5
+              with:
+                  path: |
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                      api/target
+                  key: ${{ runner.os }}-cargo-api-${{ hashFiles('api/Cargo.lock') }}
+
+            - name: Check
+              run: cargo check
+              working-directory: api
+
+            - name: Clippy
+              run: cargo clippy -- -D warnings
+              working-directory: api
+
+            - name: Check formatting
+              run: cargo fmt --check
+              working-directory: api
+
+    check-app:
+        name: Check App
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v7
+
+            - uses: oven-sh/setup-bun@v2
+
+            - name: Install dependencies
+              run: bun install
+              working-directory: app
+
+            - name: Run checks
+              run: bun run check
+              working-directory: app
+
+    check-app-tauri:
+        name: Check App Tauri
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v7
+
+            - name: Cache cargo
+              uses: actions/cache@v5
+              with:
+                  path: |
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                      app/src-tauri/target
+                  key: ${{ runner.os }}-cargo-tauri-${{ hashFiles('app/src-tauri/Cargo.lock') }}
+
+            - name: Check
+              run: cargo check
+              working-directory: app/src-tauri
+
+            - name: Clippy
+              run: cargo clippy -- -D warnings
+              working-directory: app/src-tauri
+
+            - name: Check formatting
+              run: cargo fmt --check
+              working-directory: app/src-tauri

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,17 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
+            - name: Install system dependencies
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y \
+                      libwebkit2gtk-4.1-dev \
+                      libgtk-3-dev \
+                      libsoup-3.0-dev \
+                      libjavascriptcoregtk-4.1-dev \
+                      librsvg2-dev \
+                      patchelf
+
             - name: Cache cargo
               uses: actions/cache@v5
               with:


### PR DESCRIPTION
## Summary
- Added a new `check.yml` workflow that runs Rust and Bun checks on pull requests
- Removed redundant check steps from `build.yml` (they are now covered by the PR check workflow)
- Changed `build.yml` trigger from `workflow_dispatch` to `push` on `main` so builds run automatically on merge

## Testing
- Check workflow runs on pull requests to `main` — not yet verified
- Build workflow triggers on push to `main` — not yet verified
- `cargo check`, `clippy`, `fmt --check` pass for `api/` — not run
- `cargo check`, `clippy`, `fmt --check` pass for `app/src-tauri/` — not run
- `bun install && bun run check` passes for `app/` — not run