### PR TITLE
Fix clippy warning: remove unnecessary borrow in format! call

### DIFF
--- a/api/src/websocket/mod.rs
+++ b/api/src/websocket/mod.rs
@@ -183,7 +183,7 @@ pub async fn handle_socket(
 							}
 						} else if let Err(err) = send_error_to_client(
 							&sender,
-							&format!("Unknown module: {}", &env.module)
+							&format!("Unknown module: {}", env.module)
 						).await {
 							eprintln!("{err}");
 							break;


### PR DESCRIPTION
## Summary

- Removes an unnecessary `&` borrow of `env.module` inside a `format!` call in the websocket handler.
- Resolves Clippy lint warning about redundant borrowing.

## Testing

- Verified the project compiles without clippy warnings related to this change.
- Not run: full integration or e2e tests (no logic change, purely stylistic).